### PR TITLE
fix: correct horizontal frequency formulas

### DIFF
--- a/src/fft3d_engine.h
+++ b/src/fft3d_engine.h
@@ -238,7 +238,7 @@ public:
       for (i = 0; i < ep->ow; i++)
       {
         iop->wanxl[i] = sqrt(cosf(pi*(i - ep->ow + 0.5f) / (ep->ow * 2)));
-        iop->wanxr[i] = sqrt(cosf(pi*(i + 0.5f) / (ep->oh * 2)));
+        iop->wanxr[i] = sqrt(cosf(pi*(i + 0.5f) / (ep->ow * 2)));
       }
       for (i = 0; i < ep->oh; i++)
       {
@@ -354,7 +354,7 @@ public:
         fh2 = ((ep->bh - 1 - j)*2.0f / ep->bh)*((ep->bh - 1 - j)*2.0f / ep->bh);
       for (i = 0; i < outwidth; i++)
       {
-        fw2 = (i*2.0f / ep->bw)*(j*2.0f / ep->bw);
+        fw2 = (i*2.0f / ep->bw)*(i*2.0f / ep->bw);
         pwin[i] = (fh2 + fw2) / (fh2 + fw2 + ep->pcutoff*ep->pcutoff);
       }
       pwin += outpitch;


### PR DESCRIPTION
> Disclosure: This report was prepared by OpenAI Codex, a GPT-based
> coding agent, after inspecting `FFT3DFilter.cpp`. The GitHub
> user posting this issue is forwarding the report and is not claiming
> authorship of the analysis.

I reviewed the FFT3DFilter 2.12 source and found two expressions that
look like possible long-standing typos. These observations are based on
static source analysis; I have not performed runtime output comparisons.

## 1. Horizontal analysis window uses the vertical overlap size

In the `wintype == 1` branch, the following loop initializes the
horizontal analysis windows:

```cpp
for (i = 0; i < ow; i++)
{
  wanxl[i] = sqrt(cosf(pi*(i - ow + 0.5f) / (ow * 2)));
  wanxr[i] = sqrt(cosf(pi*(i + 0.5f) / (oh * 2)));
}
```

The denominator of `wanxr` uses `oh`, the vertical overlap size, while
the loop and both arrays are horizontal.

I suspect the intended expression is:

```cpp
wanxr[i] = sqrt(cosf(pi*(i + 0.5f) / (ow * 2)));
```

This would restore the expected left/right symmetry:

```text
wanxr[i] == wanxl[ow - 1 - i]
```

The current behavior is normally hidden when `ow == oh`.

## 2. Horizontal pattern-frequency term multiplies `i` by `j`

The pattern cutoff window currently calculates:

```cpp
fw2 = (i*2.0f / bw)*(j*2.0f / bw);
```

Since `fh2` already contains the squared vertical-frequency term, and
`fw2` appears to mean “frequency width squared,” I suspect the second
`j` should be `i`:

```cpp
fw2 = (i*2.0f / bw)*(i*2.0f / bw);
```

With the existing expression, `fw2` is zero for every horizontal
frequency when `j == 0`. As a result, the entire horizontal frequency
axis receives a zero pattern-window weight, including bins where
`i > 0`.

## Compatibility considerations

Both expressions appear to have existed since the original
implementations of these features. Correcting them could therefore
change output for scripts using:

- `wintype=1` with unequal horizontal and vertical overlap sizes;
- noise-pattern processing with `pfactor > 0`.

These cases are outside the common defaults, which may explain why the
behavior has remained unnoticed.

### Appendix: Algorithm analysis for typo 2

I reviewed the complete data flow related to `pwin`, from the FFT layout and pattern-window construction through pattern estimation and its use by the Wiener and Kalman filters.

In this loop, `i` is the horizontal frequency index and `j` is the vertical FFT row. `fh2` represents the squared vertical frequency, while `fw2` is expected to represent the squared horizontal frequency:

```cpp
fw2 = (i*2.0f / bw)*(j*2.0f / bw);
```

The current multiplication is inconsistent for several reasons:

- `fw2` is not a square, despite its name.
- When `j == 0`, both `fh2` and `fw2` are zero for every `i`. Consequently, `pwin` is zero across the entire horizontal frequency axis, including the horizontal Nyquist frequency.
- The second factor uses the raw vertical row `j`, but normalizes it by the block width `bw`. This does not form a consistently normalized horizontal, vertical, or cross-frequency term.
- Rows with the same computed `fh2` can receive very different weights solely because the unmodified `j` is used in `fw2`.

For example, with `bw = bh = 32` and `pcutoff = 0.1`, the current expression gives a weight of `0` at `j = 0, i = 16`. Replacing `j` with `i` gives approximately `0.990099`, which is consistent with that bin being a high horizontal frequency.

Other frequency-dependent windows in the same algorithm use a squared radial distance of the form `vertical_frequency² + horizontal_frequency²`. The alternative noise-pattern construction also uses `fx² + fy²`. This makes the internally consistent expression:

```cpp
fw2 = (i*2.0f / bw)*(i*2.0f / bw);
```

My conclusion is that `i*j` is very likely a long-standing typographical error and that `i*i` is the intended expression. This is based on the algorithm’s internal structure and observable numerical properties, not on a statement from the original author. I would therefore describe it as a “likely typo” rather than claim the original intent as an absolute fact.

*Analysis prepared by OpenAI Codex/GPT from a source-level review of the algorithm.*
