### PR TITLE
fix: preserve grid sample base during pattern search

### DIFF
--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -60,14 +60,15 @@ void FindPatternBlock(fftwf_complex *outcur0, int outwidth, int outpitch, int bh
     {
       outcur = outcur0 + nox*by*bh*outpitch + bx*bh*outpitch;
       sigmaSquaredcur = 0;
-      float gcur = degrid*outcur[0][0] / gridsample[0][0]; // grid (windowing) correction factor
+      const fftwf_complex *gridrow = gridsample;
+      float gcur = degrid*outcur[0][0] / gridrow[0][0]; // grid (windowing) correction factor
       for (h = 0; h < bh; h++)
       {
         for (w = 0; w < outwidth; w++)
         {
           //					psd = outcur[w][0]*outcur[w][0] + outcur[w][1]*outcur[w][1];
-          float grid0 = gcur*gridsample[w][0];
-          float grid1 = gcur*gridsample[w][1];
+          float grid0 = gcur*gridrow[w][0];
+          float grid1 = gcur*gridrow[w][1];
           float corrected0 = outcur[w][0] - grid0;
           float corrected1 = outcur[w][1] - grid1;
           psd = corrected0*corrected0 + corrected1*corrected1;
@@ -75,7 +76,7 @@ void FindPatternBlock(fftwf_complex *outcur0, int outwidth, int outpitch, int bh
         }
         outcur += outpitch;
         pwin += outpitch;
-        gridsample += outpitch;
+        gridrow += outpitch;
       }
       pwin -= outpitch*bh; // restore
       if (sigmaSquaredcur < sigmaSquared)


### PR DESCRIPTION
This is also reported to upstream https://github.com/pinterf/fft3dfilter/issues/9

> Disclosure: This report was prepared by OpenAI Codex, a GPT-based coding agent, after inspecting FFT3DFilter.
> The GitHub user posting this issue is forwarding the report and is not claiming authorship of the analysis.

## Summary

`FindPatternBlock()` appears to lose the base address of `gridsample` while evaluating candidate pattern blocks.

The constructor deliberately calculates only one FFT block for `gridsample`:

```cpp
// but use one block only for speed
plan1 = fftfp.fftwf_plan_many_dft_r2c(rank, ndim, 1, ...);
...
fftfp.fftwf_execute_dft_r2c(plan1, in, gridsample);
```

This is consistent with the algorithm: `gridsample` is the FFT of the fixed analysis-window response, so the same spectrum is reused for every image block.

However, `FindPatternBlock()` advances the pointer once per FFT row:

```cpp
for (h = 0; h < bh; h++)
{
  ...
  gridsample += outpitch;
}
```

After one candidate, the pointer has advanced by one complete FFT block. `pwin` is restored at the end of the candidate, but `gridsample` is not. Consequently, the first candidate uses the initialized grid spectrum while subsequent candidates read later `gridsample` blocks that were never produced by `plan1`.

This affects automatic pattern-block selection when `px == 0 && py == 0`. Manual block selection does not call `FindPatternBlock()` and is therefore not affected by this specific pointer error.

## Suggested fix

The minimal fix is to restore `gridsample` together with `pwin` after every candidate:

```cpp
pwin -= outpitch * bh;
gridsample -= outpitch * bh;
```

A less error-prone version would keep the function argument unchanged and create a local row pointer for each candidate:

```cpp
const fftwf_complex *gridrow = gridsample;
for (h = 0; h < bh; ++h)
{
  // use gridrow[w]
  gridrow += outpitch;
}
```

This makes the intended invariant explicit: every candidate is compared using the same grid spectrum.

## Appendix: Algorithm analysis

### 1. What `gridsample` represents

Let the spatial analysis window be `a(x, y)`, and let its two-dimensional DFT be:

```text
G(k) = DFT{a(x, y)}
```

Windowing a locally constant image block with level `c` creates the spectrum:

```text
DFT{c * a(x, y)} = c * G(k)
```

This deterministic spectrum is the grid or window-leakage component that the degrid operation attempts to subtract. The analysis window and FFT dimensions are identical for all overlapped image blocks, so `G(k)` is block-independent. This is why calculating it once is sufficient and why the constructor passes `howmany = 1` to `plan1`.

For a candidate block `b`, let its measured spectrum be `X_b(k)`. The code estimates the grid amplitude from the DC coefficient:

```text
g_b = degrid * X_b(0) / G(0)
```

It then calculates the corrected residual:

```text
R_b(k) = X_b(k) - g_b * G(k)
```

and scores the candidate with the pattern window `W(k)`:

```text
S_b = sum_k |R_b(k)|^2 * W(k)
```

The candidate with the smallest `S_b` is selected as the noise-pattern block.

The important invariant is that `G(k)` is the same function for every `b`. Only `X_b(k)` and the scalar `g_b` change between candidates.

### 2. How the pointer violates that invariant

Let one stored FFT block occupy:

```text
B = bh * outpitch
```

complex elements, and let `P` be the original `gridsample` pointer. `plan1` initializes the range corresponding to the first block:

```text
[P, P + B)
```

During the first candidate, the row loop walks through that range. At the end of the loop, the mutable pointer has become `P + B`. Since it is not restored, candidate number `q` starts from:

```text
P_q = P + qB
```

For every `q >= 1`, this is not the spectrum initialized by `plan1`. The code therefore evaluates a different expression from the intended score:

```text
intended: S_b = sum_k |X_b(k) - g_b G(k)|^2 W(k)
actual:   S_b = sum_k |X_b(k) - g_b U_b(k)|^2 W(k)
```

where `U_b(k)` denotes indeterminate contents in an uninitialized later block. There is no algorithmic reason for `U_b(k)` to represent the grid response.

### 3. Expected failure modes

The exact symptom depends on the contents of the uninitialized FFT storage:

- If a later block contains zeros, the DC division can produce an infinity, and multiplying that value by zero can produce NaNs. A NaN score cannot satisfy `sigmaSquaredcur < sigmaSquared`, so that candidate cannot replace the current minimum.
- If it contains arbitrary finite values, later candidates receive arbitrary degrid corrections and incomparable scores.
- If it happens to contain stale FFT-like data, the result may look numerically plausible but still uses a spectrum unrelated to the fixed analysis window.

This means that remaining on the first tested candidate, `(2, 2)`, is a plausible and likely symptom in zero-initialized implementations, but it is not the only possible outcome in the original allocation model. The general bug is that all candidates after the first are scored from data that `plan1` did not initialize.

### 4. Internal consistency check

Other degrid loops in the code advance `gridsample` while processing the rows of one block and then subtract `outpitch * bh` before processing the next block. Their comments explicitly describe restoring the pointer to the only valid first block.

`FindPatternBlock()` restores `pwin` in exactly this position but omits the corresponding restoration for `gridsample`. Adding it matches both the mathematical invariant and the established pointer-management pattern elsewhere in the implementation.

## Confidence and limitations

Confidence that the pointer progression is incorrect is high. It follows directly from the `howmany = 1` FFT plan, the single execution of `plan1`, and the missing restoration in the candidate loop.

I have not performed a real-video A/B comparison. Such a comparison would help quantify the visible impact and confirm the exact symptom for a particular allocator and build, but it is not required to establish that later candidates read grid blocks that were never calculated.