### PR TITLE
fix: correct vertical pattern frequency folding

### DIFF
--- a/src/fft3d_engine.h
+++ b/src/fft3d_engine.h
@@ -345,13 +345,12 @@ public:
 
     pwin = new float[ep->bh*outpitch]; // pattern window array
 
-    float fw2, fh2;
+    float fw2;
     for (j = 0; j < ep->bh; j++)
     {
-      if (j < ep->bh / 2)
-        fh2 = (j*2.0f / ep->bh)*(j*2.0f / ep->bh);
-      else
-        fh2 = ((ep->bh - 1 - j)*2.0f / ep->bh)*((ep->bh - 1 - j)*2.0f / ep->bh);
+      const int dj = std::min(j, ep->bh - j);
+      const float fh = dj*2.0f / ep->bh;
+      const float fh2 = fh*fh;
       for (i = 0; i < outwidth; i++)
       {
         fw2 = (i*2.0f / ep->bw)*(i*2.0f / ep->bw);


### PR DESCRIPTION
This is also reported to upstream https://github.com/pinterf/fft3dfilter/issues/10

> Disclosure: This report was prepared by OpenAI Codex, a GPT-based coding agent, after inspecting FFT3DFilter.
> The GitHub user posting this issue is forwarding the report and is not claiming authorship of the analysis.

## Summary

The vertical-frequency term used to build `pwin` folds the negative-frequency half with `bh - 1 - j`:

```cpp
if (j < bh / 2)
  fh2 = (j*2.0f / bh)*(j*2.0f / bh);
else
  fh2 = ((bh - 1 - j)*2.0f / bh)
      * ((bh - 1 - j)*2.0f / bh);
```

For an FFT of height `bh`, row `j` represents signed vertical bin `j - bh` in the negative-frequency half. Its magnitude is therefore `bh - j`, not `bh - 1 - j`.

The current expression shifts the entire negative-frequency half by one bin toward DC. It also treats the final row, `j == bh - 1`, as vertical DC, although that row represents frequency bin `-1`.

For example, with `bh = 32`:

| Row `j` | Current distance | Expected distance |
| ---: | ---: | ---: |
| 16 | 15 | 16 |
| 17 | 14 | 15 |
| 30 | 1 | 2 |
| 31 | 0 | 1 |

This makes the pattern cutoff window vertically asymmetric and underweights part of the stored spectrum during automatic pattern-block scoring and pattern PSD estimation.

This issue is independent of the separate horizontal-term typo in the adjacent `fw2` expression. Correcting the horizontal multiplication does not correct the vertical folding.

## Suggested fix

Use the standard wrapped FFT-bin distance:

```cpp
const int dj = std::min(j, bh - j);
const float fh = static_cast<float>(dj) * 2.0f / bh;
const float fh2 = fh * fh;
```

An equivalent branch would use `bh - j` in the second half, but `std::min` states the intended periodic distance more directly and avoids another boundary-condition error.

## Appendix: Algorithm analysis

### 1. DFT row-to-frequency mapping

For a DFT with height `N = bh`, row indices are stored in the order:

```text
0, 1, 2, ..., N/2, -(N/2 - 1), ..., -2, -1
```

For even `N`, the signed vertical bin represented by row `j` is:

```text
k_y(j) = j,       0 <= j <= N/2
k_y(j) = j - N,   N/2 < j < N
```

The frequency window uses magnitude rather than direction, so the required non-negative distance from DC is:

```text
d(j) = |k_y(j)| = min(j, N - j)
```

Normalized so that the Nyquist distance is `1`, the squared vertical term is:

```text
fh2(j) = (2 * d(j) / N)^2
```

This gives `d(N - 1) = 1`, as expected for bin `-1`, and `d(N/2) = N/2`, as expected for the Nyquist row.

### 2. What the current expression calculates

The current second-half expression uses:

```text
d_current(j) = N - 1 - j
```

instead of:

```text
d_expected(j) = N - j
```

It therefore behaves as if the negative-frequency sequence ended at a second DC row:

```text
current:  ..., 3, 2, 1, 0
correct:  ..., 4, 3, 2, 1
```

In geometric terms, the current code measures the negative half from row `N - 1`, while the periodic DFT origin is at row `N`, which is the same location as row `0`. The wraparound distance to DC must cross that periodic boundary; subtracting one moves the boundary into the stored array.

### 3. Symmetry proof

A magnitude-only frequency window must give equal vertical weights to positive and negative bins of the same magnitude. For `1 <= j < N/2`, the positive bin `+j` is stored at row `j`, and the negative bin `-j` is stored at row `N - j`.

The correct mapping satisfies:

```text
d(j) = j
d(N - j) = N - (N - j) = j
```

The current mapping gives:

```text
d_current(j) = j
d_current(N - j) = N - 1 - (N - j) = j - 1
```

Thus every negative bin in this range is assigned the magnitude of the preceding positive bin. In particular:

```text
d_current(1)     = 1
d_current(N - 1) = 0
```

The mismatch is deterministic and does not depend on floating-point rounding, FFTW planning, input content, or compiler behavior.

### 4. Effect on the cutoff weight

Ignoring the adjacent horizontal-term issue, `pwin` has the form:

```text
W(r^2) = r^2 / (r^2 + pcutoff^2)
```

where:

```text
r^2 = fw2 + fh2
```

For a positive `pcutoff`, this function is strictly increasing in `r^2`:

```text
dW / d(r^2) = pcutoff^2 / (r^2 + pcutoff^2)^2 > 0
```

Because `bh - 1 - j` is one bin smaller than `bh - j`, the current code systematically produces a smaller `fh2` throughout the negative-frequency half. Those coefficients therefore receive smaller pattern weights than their intended frequencies.

The final row demonstrates the error without approximation. At horizontal DC (`i = 0`) and `j = N - 1`:

```text
current fh2 = 0
current W   = 0
```

but the correct vertical distance is one bin:

```text
correct fh2 = (2 / N)^2
correct W   = (2 / N)^2 / ((2 / N)^2 + pcutoff^2) > 0
```

The coefficient is therefore suppressed as if it were DC even though it represents vertical frequency `-1`.

### 5. Internal consistency check

The sharpen and dehalo window construction in the same source file uses:

```cpp
int dj = j;
if (j >= bh / 2)
  dj = bh - j;
```

That is the expected wrapped FFT distance. The pattern cutoff window is the exception in using `bh - 1 - j`, even though it is also constructing a radial frequency-domain weight.

The practical scope is limited to consumers of `pwin`, primarily `FindPatternBlock()` and `SetPattern()`. It does not imply that the FFT transform itself or the main sharpen/dehalo windows use the same off-by-one mapping.

## Confidence and limitations

Confidence that `bh - 1 - j` is an off-by-one error is high. The conclusion follows from the deterministic DFT index mapping and is supported by the correct `bh - j` mapping used in adjacent frequency-window code.

I have not performed a real-video A/B comparison. Such a comparison would measure the visual significance for particular block sizes and `pcutoff` values, but it would not change the index-mapping result above.