### PR TITLE
Overhaul the concurrency model

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -559,7 +559,7 @@ static void OverlapToCover_impl(EngineParams * ep, IOParams * iop, float *src_pt
   }
 }
 
-void FrameToCover(EngineParams * ep, int plane, const byte *src_ptr, byte *coverbuf, int coverwidth, int coverheight, int coverpitch, int mirw, int mirh)
+void FrameToCover(EngineParams* ep, int plane, const byte* src_ptr, byte* coverbuf, int coverwidth, int coverheight, int coverpitch, int mirw, int mirh, int src_pitch)
 {
   auto l = ep->IsChroma ? (ep->l >> ep->vi.Format.SSW) : ep->l;
   auto r = ep->IsChroma ? (ep->r >> ep->vi.Format.SSW) : ep->r;
@@ -567,19 +567,19 @@ void FrameToCover(EngineParams * ep, int plane, const byte *src_ptr, byte *cover
   auto b = ep->IsChroma ? (ep->b >> ep->vi.Format.SSH) : ep->b;
   auto width = ep->framewidth - l - r;
   auto height = ep->frameheight - t - b;
-  auto new_src_ptr = src_ptr + (t * ep->framepitch + l) * ep->vi.Format.BytesPerSample;
+  auto new_src_ptr = src_ptr + (t * src_pitch + l) * ep->vi.Format.BytesPerSample;
   switch (ep->vi.Format.BitsPerSample)
   {
-  case 8: FrameToCover_impl<uint8_t>(new_src_ptr, width, height, ep->framepitch, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, ep->interlaced); break;
+  case 8: FrameToCover_impl<uint8_t>(new_src_ptr, width, height, src_pitch, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, ep->interlaced); break;
   case 10:
   case 12:
   case 14:
-  case 16: FrameToCover_impl<uint16_t>((uint16_t *)new_src_ptr, width, height, ep->framepitch, (uint16_t *)coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, ep->interlaced); break;
-  case 32: FrameToCover_impl<float>((float *)new_src_ptr, width, height, ep->framepitch, (float *)coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, ep->interlaced); break;
+  case 16: FrameToCover_impl<uint16_t>((uint16_t*)new_src_ptr, width, height, src_pitch, (uint16_t*)coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, ep->interlaced); break;
+  case 32: FrameToCover_impl<float>((float*)new_src_ptr, width, height, src_pitch, (float*)coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, ep->interlaced); break;
   }
 }
 
-void CoverToFrame(EngineParams * ep, int plane, const byte *coverbuf, int coverwidth, int coverheight, int coverpitch, byte *dst_ptr, int mirw, int mirh)
+void CoverToFrame(EngineParams* ep, int plane, const byte* coverbuf, int coverwidth, int coverheight, int coverpitch, byte* dst_ptr, int mirw, int mirh, int dst_pitch)
 {
   auto l = ep->IsChroma ? (ep->l >> ep->vi.Format.SSW) : ep->l;
   auto r = ep->IsChroma ? (ep->r >> ep->vi.Format.SSW) : ep->r;
@@ -587,15 +587,15 @@ void CoverToFrame(EngineParams * ep, int plane, const byte *coverbuf, int coverw
   auto b = ep->IsChroma ? (ep->b >> ep->vi.Format.SSH) : ep->b;
   auto width = ep->framewidth - l - r;
   auto height = ep->frameheight - t - b;
-  auto new_dst_ptr = dst_ptr + (t * ep->framepitch_dst + l) * ep->vi.Format.BytesPerSample;
+  auto new_dst_ptr = dst_ptr + (t * dst_pitch + l) * ep->vi.Format.BytesPerSample;
   switch (ep->vi.Format.BitsPerSample)
   {
-  case 8: CoverToFrame_impl<uint8_t>(coverbuf, coverwidth, coverheight, coverpitch, new_dst_ptr, width, height, ep->framepitch_dst, mirw, mirh, ep->interlaced); break;
+  case 8: CoverToFrame_impl<uint8_t>(coverbuf, coverwidth, coverheight, coverpitch, new_dst_ptr, width, height, dst_pitch, mirw, mirh, ep->interlaced); break;
   case 10:
   case 12:
   case 14:
-  case 16: CoverToFrame_impl<uint16_t>((uint16_t *)coverbuf, coverwidth, coverheight, coverpitch, (uint16_t *)new_dst_ptr, width, height, ep->framepitch_dst, mirw, mirh, ep->interlaced); break;
-  case 32: CoverToFrame_impl<float>((float *)coverbuf, coverwidth, coverheight, coverpitch, (float *)new_dst_ptr, width, height, ep->framepitch_dst, mirw, mirh, ep->interlaced); break;
+  case 16: CoverToFrame_impl<uint16_t>((uint16_t*)coverbuf, coverwidth, coverheight, coverpitch, (uint16_t*)new_dst_ptr, width, height, dst_pitch, mirw, mirh, ep->interlaced); break;
+  case 32: CoverToFrame_impl<float>((float*)coverbuf, coverwidth, coverheight, coverpitch, (float*)new_dst_ptr, width, height, dst_pitch, mirw, mirh, ep->interlaced); break;
   }
 }
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -5,8 +5,8 @@
 #include "fft3d_common.h"
 #include <type_traits>
 
-void FrameToCover(EngineParams * ep, int plane, const byte *src_ptr, byte *coverbuf, int coverwidth, int coverheight, int coverpitch, int mirw, int mirh);
-void CoverToFrame(EngineParams * ep, int plane, const byte *coverbuf, int coverwidth, int coverheight, int coverpitch, byte *dst_ptr, int mirw, int mirh);
+void FrameToCover(EngineParams* ep, int plane, const byte* src_ptr, byte* coverbuf, int coverwidth, int coverheight, int coverpitch, int mirw, int mirh, int src_pitch);
+void CoverToFrame(EngineParams* ep, int plane, const byte* coverbuf, int coverwidth, int coverheight, int coverpitch, byte* dst_ptr, int mirw, int mirh, int dst_pitch);
 void CoverToOverlap(EngineParams * ep, IOParams * iop, float *dst_ptr, const byte *src_ptr, int src_width, int src_pitch, bool chroma);
 void OverlapToCover(EngineParams * ep, IOParams * iop, float *src_ptr, float norm, byte *dst_ptr, int dst_width, int dst_pitch, bool chroma);
 

--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -13,39 +13,49 @@
 #include <unordered_map>
 #include <list>
 #include <cstddef>
+#include <memory>
+#include <mutex>
+#include <type_traits>
 
 template<typename value_t>
 class cache {
   public:
-    typedef typename std::pair<int32_t, value_t*> key_value_pair_t;
+    using element_t = typename std::remove_extent<value_t>::type;
+    struct Item {
+      std::shared_ptr<element_t> data;
+      std::shared_ptr<std::mutex> mtx;
+    };
+    typedef typename std::pair<int32_t, Item> key_value_pair_t;
     typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
 
     cache(size_t vault_size, size_t data_size) {
       auto alignment_size = 64 / sizeof(value_t);
       _data_size = (data_size + alignment_size - 1) & (~alignment_size);
-      resize(vault_size);
+      _max_size = vault_size;
     }
 
-    ~cache() {
-      for (auto &&i : _internal_vault)
-        _aligned_free(i);
-    }
+    ~cache() {}
 
-    value_t* get_write(const int32_t key) {
-      auto last = _cache_items_list.end();
-      last--;
-      auto data = last->second;
-      _cache_items_map.erase(last->first);
-      _cache_items_list.pop_back();
-      _cache_items_list.push_front(key_value_pair_t(key, data));
+    Item get_write(const int32_t key) {
+      if (_cache_items_list.size() >= _max_size) {
+        auto last = _cache_items_list.end();
+        last--;
+        _cache_items_map.erase(last->first);
+        _cache_items_list.pop_back();
+      }
+      auto deleter = [](element_t* ptr) { _aligned_free(ptr); };
+      std::shared_ptr<element_t> mem((element_t*)_aligned_malloc(sizeof(value_t) * _data_size, FRAME_ALIGN), deleter);
+      Item item{mem, std::make_shared<std::mutex>()};
+        
+      _cache_items_list.push_front(key_value_pair_t(key, item));
       _cache_items_map[key] = _cache_items_list.begin();
-      return data;
+      return item;
     }
 
-    value_t* get_read(const int32_t key) {
+    Item get_read(const int32_t key) {
       auto it = _cache_items_map.find(key);
       if (it == _cache_items_map.end())
-        return NULL;
+        return {nullptr, nullptr};
 
       _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
       return it->second->second;
@@ -63,18 +73,14 @@ class cache {
     }
 
     void resize(size_t new_vault_size) {
-      while (_internal_vault.size() < new_vault_size) {
-        auto mem = (value_t*)_aligned_malloc(sizeof(value_t) * _data_size, FRAME_ALIGN);
-        _internal_vault.push_back(mem);
-        _cache_items_list.push_back(key_value_pair_t(-1, mem));
-      }
+      _max_size = new_vault_size;
     }
 
   private:
     std::list<key_value_pair_t> _cache_items_list;
     std::unordered_map<int32_t, list_iterator_t> _cache_items_map;
-    std::vector<value_t*> _internal_vault;
-    size_t _data_size {0};
+    size_t _data_size{0};
+    size_t _max_size{0};
 };
 
 #endif

--- a/src/fft3d.hpp
+++ b/src/fft3d.hpp
@@ -175,6 +175,7 @@ struct FFT3D final : Filter {
     fftfp.load();
 
     if (fft_threads > 1 && fftfp.has_threading()) {
+      GlobalLockGuard fftw_lock(ep->avs_env, "fftw", ep->has_at_least_v12);
       fftfp.fftwf_init_threads();
       fftfp.fftwf_plan_with_nthreads(fft_threads);
     }

--- a/src/fft3d_common.h
+++ b/src/fft3d_common.h
@@ -82,8 +82,6 @@ struct EngineParams {
 
   int framewidth; // in pixels, not bytes
   int frameheight;
-  int framepitch; // in pixels, not bytes
-  int framepitch_dst; // in pixels, not bytes
 };
 
 

--- a/src/fft3d_engine.h
+++ b/src/fft3d_engine.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <thread>
 #include <unordered_map>
+#include <mutex>
 
 class FFT3DEngine {
   EngineParams* ep;
@@ -60,9 +61,10 @@ class FFT3DEngine {
   float *pwin;
   float *pattern2d;
   float *pattern3d;
-  bool isPatternSet;
+  std::atomic<bool> isPatternSet{ false };
   float psigma {0};
-  char *messagebuf;
+  std::mutex pshow_mutex;
+  std::mutex pattern_mutex;
 
   // added in v.0.9 for delayed FFTW3.DLL loading
   struct FFTFunctionPointers fftfp;
@@ -348,7 +350,7 @@ public:
     float fw2;
     for (j = 0; j < ep->bh; j++)
     {
-      const int dj = std::min(j, ep->bh - j);
+      const int dj = (std::min)(j, ep->bh - j);
       const float fh = dj*2.0f / ep->bh;
       const float fh2 = fh*fh;
       for (i = 0; i < outwidth; i++)
@@ -403,7 +405,6 @@ public:
     // make FFT 2D
     fftfp.fftwf_execute_dft_r2c(plan1, in, gridsample);
 
-    messagebuf = (char *)malloc(80); //1.8.5
 
   }
   ~FFT3DEngine() {
@@ -446,13 +447,22 @@ public:
     for (auto it : mt_coverbuf)
       _aligned_free(it);
 
-    free(messagebuf); //v1.8.5
   }
 
   DSFrame GetFrame(int n, std::unordered_map<int, DSFrame> in_frames) {
     unsigned int thread_id;
     DSFrame src, psrc, dst;
     int pxf, pyf;
+
+    // RAII guard to return the thread slot even on exceptions
+    struct ThreadSlotGuard {
+      std::vector<int>&slots;
+      size_t idx;
+      std::mutex & mtx;
+      ThreadSlotGuard(std::vector<int>&s, size_t i, std::mutex & m) : slots(s), idx(i), mtx(m) {}
+      ~ThreadSlotGuard() { std::lock_guard<std::mutex> lock(mtx); slots[idx] = 0; }
+        
+    };
 
     byte* coverbuf;
     float *in;
@@ -478,32 +488,42 @@ public:
       else
         thread_id_store[thread_id] = 1;
     }
+    ThreadSlotGuard slot_guard(thread_id_store, thread_id, thread_check_mutex);
     coverbuf = mt_coverbuf[thread_id];
     in = mt_in[thread_id];
     outrez = mt_out[thread_id];
 
     if (ep->pfactor != 0) {
-      GlobalLockGuard fftw_lock(ep->avs_env, "fftw", ep->has_at_least_v12);
-      if (ep->pfactor != 0 && isPatternSet == false && ep->pshow == false) // get noise pattern
-      {
+      DSFrame patternSourceFrame;
+      bool needPatternFrame = (!isPatternSet.load(std::memory_order_acquire) && ep->pshow == false);
+        
+      if (needPatternFrame) {
         if (in_frames.find(ep->pframe) == in_frames.end())
-          psrc = (*fetch_frame)(ep->pframe);
+                 patternSourceFrame = (*fetch_frame)(ep->pframe);
         else
-          psrc = in_frames[ep->pframe];
-        auto sptr = psrc.SrcPointers[plane];
-        ep->framepitch = psrc.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
-
-        // put source bytes to float array of overlapped blocks
-        FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh);
-        CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
-        fftfp.fftwf_execute_dft_r2c(plan, in, outrez);
-        if (ep->px == 0 && ep->py == 0) // try find pattern block with minimal noise sigma
-          FindPatternBlock(outrez, outwidth, outpitch, ep->bh, iop->nox, iop->noy, ep->px, ep->py, pwin, ep->degrid, gridsample);
-        SetPattern(outrez, outwidth, outpitch, ep->bh, iop->nox, iop->noy, ep->px, ep->py, pwin, pattern2d, psigma, ep->degrid, gridsample);
-        isPatternSet = true;
+                 patternSourceFrame = in_frames[ep->pframe];
       }
-      else if (ep->pfactor != 0 && ep->pshow == true)
-      {
+        
+      if (needPatternFrame) {
+        auto sptr = patternSourceFrame.SrcPointers[plane];
+        int src_pitch = patternSourceFrame.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
+            
+        FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, src_pitch);
+        CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
+            fftfp.fftwf_execute_dft_r2c(plan, in, outrez);
+            
+        {
+          std::lock_guard<std::mutex> lock(pattern_mutex);
+          if (!isPatternSet.load(std::memory_order_relaxed)) {
+            if (ep->px == 0 && ep->py == 0)
+              FindPatternBlock(outrez, outwidth, outpitch, ep->bh, iop->nox, iop->noy, ep->px, ep->py, pwin, ep->degrid, gridsample);
+            SetPattern(outrez, outwidth, outpitch, ep->bh, iop->nox, iop->noy, ep->px, ep->py, pwin, pattern2d, psigma, ep->degrid, gridsample);
+                    isPatternSet.store(true, std::memory_order_release);
+          }
+        }   
+      }
+      else if (ep->pshow == true) {
+        std::lock_guard<std::mutex> pshow_lock(pshow_mutex);
         // show noise pattern window
         if (in_frames.find(n) == in_frames.end())
           src = (*fetch_frame)(n);
@@ -512,11 +532,11 @@ public:
         dst = src.Create(true);
         auto sptr = src.SrcPointers[plane];
         auto dptr = dst.DstPointers[plane];
-        ep->framepitch = src.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
-        ep->framepitch_dst = dst.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
+        const int src_pitch = src.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
+        const int dst_pitch = dst.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
 
         // put source bytes to float array of overlapped blocks
-        FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh);
+        FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, src_pitch);
         CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
         // make FFT 2D
         fftfp.fftwf_execute_dft_r2c(plan, in, outrez);
@@ -541,7 +561,7 @@ public:
 
         // put source bytes to float array of overlapped blocks
         // cur frame
-        FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh);
+        FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, src_pitch);
         CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, !ep->vi.Format.IsFamilyRGB);
         // make FFT 2D
         fftfp.fftwf_execute_dft_r2c(plan, in, outrez);
@@ -552,15 +572,12 @@ public:
 
         // make destination frame plane from current overlaped blocks
         OverlapToCover(ep, iop, in, norm, coverbuf, coverwidth, coverpitch, !ep->vi.Format.IsFamilyRGB);
-        CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh);
+        CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh, dst_pitch);
         int psigmaint = ((int)(10 * psigma)) / 10;
         int psigmadec = (int)((psigma - psigmaint) * 10);
-        wsprintf(messagebuf, " frame=%d, px=%d, py=%d, sigma=%d.%d", n, pxf, pyf, psigmaint, psigmadec);
-        // TODO: DrawString(dst, vi, 0, 0, messagebuf);
-        {
-          std::lock_guard<std::mutex> lock(thread_check_mutex);
-          thread_id_store[thread_id] = 0;
-        }
+        char local_messagebuf[80];
+        wsprintf(local_messagebuf, " frame=%d, px=%d, py=%d, sigma=%d.%d", n, pxf, pyf, psigmaint, psigmadec);
+        // TODO: DrawString(dst, vi, 0, 0, local_messagebuf);
         return dst; // return pattern frame to show
       }
     }
@@ -573,8 +590,8 @@ public:
     dst = src.Create(false);
     auto sptr = src.SrcPointers[plane];
     auto dptr = dst.DstPointers[plane];
-    ep->framepitch = src.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
-    ep->framepitch_dst = dst.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
+    const int src_pitch = src.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
+    const int dst_pitch = dst.StrideBytes[plane] / ep->vi.Format.BytesPerSample;
 
     int btcur = ep->bt; // bt used for current frame
   //	if ( (bt/2 > n) || bt==3 && n==vi.num_frames-1 )
@@ -613,7 +630,7 @@ public:
       if (btcur == 1) // 2D
       {
         // cur frame
-        FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh);
+          FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, src_pitch);
         CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
         fftfp.fftwf_execute_dft_r2c(plan, in, outrez);
         ffp.Apply2D(outrez, sfp);
@@ -643,28 +660,40 @@ public:
         *
         */
 
-        {
-          std::lock_guard<std::mutex> lock1(cache_mutex);
-          for (auto i = from; i <= to; i++)
-          {
-            if (fftcache->exists(n+i)) {
-              apply_in[2+i] = fftcache->get_read(n+i);
-            }
-            else {
-              DSFrame frame;
-              DSFrame* pframe;
-              apply_in[2+i] = fftcache->get_write(n+i);
-              if (in_frames.find(n+i) == in_frames.end())
-                pframe = &(frame = (*fetch_frame)(n+i));
-              else
-                pframe = &in_frames[n+i];
-              FrameToCover(ep, plane, pframe->SrcPointers[plane], coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh);
-              CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
+        std::vector<cache<fftwf_complex>::Item> items(to - from + 1);
+        std::vector<std::unique_lock<std::mutex>> locks;
+        locks.reserve(to - from + 1);
 
-              fftfp.fftwf_execute_dft_r2c(plan, in, apply_in[2+i]);
+        for (auto i = from; i <= to; i++)
+        {
+          bool is_new = false;
+          {
+            std::lock_guard<std::mutex> lock1(cache_mutex);
+            items[i - from] = fftcache->get_read(n+i);
+            if (!items[i - from].data) {
+              items[i - from] = fftcache->get_write(n+i);
+              is_new = true;
             }
           }
+
+          locks.emplace_back(*items[i - from].mtx);
+          apply_in[2 + i] = reinterpret_cast<fftwf_complex*>(items[i - from].data.get());
+
+          if (is_new) {
+            DSFrame frame;
+            DSFrame* pframe;
+            if (in_frames.find(n+i) == in_frames.end())
+              pframe = &(frame = (*fetch_frame)(n+i));
+            else
+              pframe = &in_frames[n+i];
+            int src_pitch_3d = pframe->StrideBytes[plane] / ep->vi.Format.BytesPerSample;
+            FrameToCover(ep, plane, pframe->SrcPointers[plane], coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, src_pitch_3d);
+            CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
+            fftfp.fftwf_execute_dft_r2c(plan, in, apply_in[2+i]);
+          }
         }
+
+        locks.clear();
 
         ffp.Apply3D(apply_in, outrez, sfp);
         ffp.Sharpen(outrez, sfp);
@@ -674,15 +703,11 @@ public:
       fftfp.fftwf_execute_dft_c2r(planinv, outrez, in);
       // make destination frame plane from current overlaped blocks
       OverlapToCover(ep, iop, in, norm, coverbuf, coverwidth, coverpitch, ep->IsChroma);
-      CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh);
+      CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh, dst_pitch);
     }
     else if (ep->bt == 0) //Kalman filter
     {
       if (n == 0) {
-       {
-         std::lock_guard<std::mutex> lock(thread_check_mutex);
-         thread_id_store[thread_id] = 0;
-       }
        return src; // first frame  not processed
       }
       /* PF 170302 comment: accumulated error?
@@ -693,7 +718,7 @@ public:
 
       // put source bytes to float array of overlapped blocks
       // cur frame
-      FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh);
+      FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, src_pitch);
       CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
       fftfp.fftwf_execute_dft_r2c(plan, in, outrez);
       ffp.Kalman(outrez, outLast, sfp);
@@ -707,12 +732,12 @@ public:
       fftfp.fftwf_execute_dft_c2r(planinv, outrez, in);
       // make destination frame plane from current overlaped blocks
       OverlapToCover(ep, iop, in, norm, coverbuf, coverwidth, coverpitch, ep->IsChroma);
-      CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh);
+      CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh, dst_pitch);
 
     }
     else if (ep->bt == -1) /// sharpen only
     {
-      FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh);
+      FrameToCover(ep, plane, sptr, coverbuf, coverwidth, coverheight, coverpitch, mirw, mirh, src_pitch);
       CoverToOverlap(ep, iop, in, coverbuf, coverwidth, coverpitch, ep->IsChroma);
       fftfp.fftwf_execute_dft_r2c(plan, in, outrez);
       ffp.Sharpen(outrez, sfp);
@@ -720,13 +745,7 @@ public:
       fftfp.fftwf_execute_dft_c2r(planinv, outrez, in);
       // make destination frame plane from current overlaped blocks
       OverlapToCover(ep, iop, in, norm, coverbuf, coverwidth, coverpitch, ep->IsChroma);
-      CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh);
-
-    }
-
-    {
-      std::lock_guard<std::mutex> lock(thread_check_mutex);
-      thread_id_store[thread_id] = 0;
+      CoverToFrame(ep, plane, coverbuf, coverwidth, coverheight, coverpitch, dptr, mirw, mirh, dst_pitch);
     }
 
     // As we now are finished processing the image, we return the destination image.


### PR DESCRIPTION
- cache use-after-free — threads could read cache data that another thread had already evicted and freed. Fix with shared_ptr and per-item mutexes.
- 3D filtering serialization — a global lock was held during FFT execution, forcing all threads to run one at a time. Fix by releasing locks before Apply3D.
- framepitch data race — multiple threads overwrote the shared ep->framepitch simultaneously, potentially causing memory corruption. Fix by passing pitch as a local variable.
- isPatternSet data race — a plain bool was read/written concurrently (undefined behavior). Fix with std::atomic<bool>.
- thread slot leak on exception — if fetch_frame threw, the thread slot was permanently stuck as "in use". Fix with an RAII guard.
- unprotected FFTW init — fftwf_init_threads() mutated global FFTW state without a lock. Fix with GlobalLockGuard.
- pshow data races — diagnostic mode mutated shared window arrays and messagebuf concurrently. Fix with a local mutex and stack buffer.